### PR TITLE
Avoid `-Wmissing-signatures` warnings on GHC 9.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.8.4"]
-        cabal: ["3.4.0.0"]
+        ghc-ver: ["8.8.4", "8.10.7", "9.0.2", "9.2.2"]
+        cabal: ["3.6.2.0"]
       # complete all jobs
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        name: [linux-8.8.4]
-        include:
-        - name: linux-8.8.4
-          ghc-ver: 8.8.4
+        ghc-ver: ["8.8.4"]
+        cabal: ["3.4.0.0"]
       # complete all jobs
       fail-fast: false
     steps:
@@ -18,24 +16,25 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Get GHC
-      run: |
-        ghcup install ghc ${{ matrix.ghc-ver }}
-        ghcup install cabal 3.4.0.0
-        ghcup set ghc ${{ matrix.ghc-ver }}
-    - name: Cache
-      uses: actions/cache@v1
-      with:
-        path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
-        # Prefer previous SHA hash if it is still cached
-        key: ${{ matrix.name }}-${{ github.sha }}
-        # otherwise just use most recent build.
-        restore-keys: ${{ matrix.name }}
     - name: Link cabal project files
       run: |
         ln -s cabal.project.dist                                  cabal.project
         ln -s cabal.project.werror                                cabal.project.local
         ln -s cabal.project.dist.freeze.ghc-${{ matrix.ghc-ver }} cabal.project.freeze
+    - uses: haskell/actions/setup@v1
+      id: setup-haskell
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal }}
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
+        # Prefer previous SHA hash if it is still cached
+        key: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        # otherwise just use most recent build.
+        restore-keys: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}
     - name: Cabal update
       run: cabal update
     - name: Cabal build

--- a/cabal.project.dist.freeze.ghc-8.10.7
+++ b/cabal.project.dist.freeze.ghc-8.10.7
@@ -1,0 +1,13 @@
+active-repositories: hackage.haskell.org:merge
+constraints: any.array ==0.5.4.0,
+             any.base ==4.14.3.0,
+             any.binary ==0.8.8.0,
+             any.bytestring ==0.10.12.0,
+             any.containers ==0.6.5.1,
+             any.deepseq ==1.4.4.0,
+             any.ghc-prim ==0.6.1,
+             any.integer-gmp ==1.0.3.0,
+             any.mtl ==2.2.2,
+             any.rts ==1.0.1,
+             any.transformers ==0.5.6.2
+index-state: hackage.haskell.org 2022-04-28T12:52:36Z

--- a/cabal.project.dist.freeze.ghc-8.8.4
+++ b/cabal.project.dist.freeze.ghc-8.8.4
@@ -10,4 +10,4 @@ constraints: any.array ==0.5.4.0,
              any.mtl ==2.2.2,
              any.rts ==1.0,
              any.transformers ==0.5.6.2
-index-state: hackage.haskell.org 2020-10-14T20:58:19Z
+index-state: hackage.haskell.org 2022-04-28T12:52:36Z

--- a/cabal.project.dist.freeze.ghc-9.0.2
+++ b/cabal.project.dist.freeze.ghc-9.0.2
@@ -1,0 +1,13 @@
+active-repositories: hackage.haskell.org:merge
+constraints: any.array ==0.5.4.0,
+             any.base ==4.15.1.0,
+             any.binary ==0.8.8.0,
+             any.bytestring ==0.10.12.1,
+             any.containers ==0.6.4.1,
+             any.deepseq ==1.4.5.0,
+             any.ghc-bignum ==1.1,
+             any.ghc-prim ==0.7.0,
+             any.mtl ==2.2.2,
+             any.rts ==1.0.2,
+             any.transformers ==0.5.6.2
+index-state: hackage.haskell.org 2022-04-28T12:52:36Z

--- a/cabal.project.dist.freeze.ghc-9.2.2
+++ b/cabal.project.dist.freeze.ghc-9.2.2
@@ -1,0 +1,16 @@
+active-repositories: hackage.haskell.org:merge
+constraints: any.array ==0.5.4.0,
+             any.base ==4.16.1.0,
+             any.binary ==0.8.9.0,
+             any.bytestring ==0.11.3.0,
+             any.containers ==0.6.5.1,
+             any.deepseq ==1.4.6.1,
+             any.ghc-bignum ==1.2,
+             any.ghc-boot-th ==9.2.2,
+             any.ghc-prim ==0.8.0,
+             any.mtl ==2.2.2,
+             any.pretty ==1.1.3.6,
+             any.rts ==1.0.2,
+             any.template-haskell ==2.18.0.0,
+             any.transformers ==0.5.6.2
+index-state: hackage.haskell.org 2022-04-28T12:52:36Z

--- a/src/Data/Dwarf/AT.hs
+++ b/src/Data/Dwarf/AT.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- We currently disable -Wmissing-signatures as a way to avoid warnings on
+-- GHC 9.2, which emits -Wmissing-signatures warnings related to pattern
+-- synonyms even if -Wmissing-pattern-synonym-signatures is disabled. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/14794#note_424553. If that
+-- issue is resolved in a subsequent minor release of GHC 9.2, we can remove
+-- this workaround.
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Data.Dwarf.AT where
 
 import qualified Data.ByteString as B

--- a/src/Data/Dwarf/Form.hs
+++ b/src/Data/Dwarf/Form.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- We currently disable -Wmissing-signatures as a way to avoid warnings on
+-- GHC 9.2, which emits -Wmissing-signatures warnings related to pattern
+-- synonyms even if -Wmissing-pattern-synonym-signatures is disabled. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/14794#note_424553. If that
+-- issue is resolved in a subsequent minor release of GHC 9.2, we can remove
+-- this workaround.
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Data.Dwarf.Form where
 
 import qualified Data.Map.Strict as Map

--- a/src/Data/Dwarf/TAG.hs
+++ b/src/Data/Dwarf/TAG.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- We currently disable -Wmissing-signatures as a way to avoid warnings on
+-- GHC 9.2, which emits -Wmissing-signatures warnings related to pattern
+-- synonyms even if -Wmissing-pattern-synonym-signatures is disabled. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/14794#note_424553. If that
+-- issue is resolved in a subsequent minor release of GHC 9.2, we can remove
+-- this workaround.
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Data.Dwarf.TAG where
 
 import           Data.Binary.Get (Get)

--- a/src/Data/Dwarf/Types.hs
+++ b/src/Data/Dwarf/Types.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+-- We currently disable -Wmissing-signatures as a way to avoid warnings on
+-- GHC 9.2, which emits -Wmissing-signatures warnings related to pattern
+-- synonyms even if -Wmissing-pattern-synonym-signatures is disabled. See
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/14794#note_424553. If that
+-- issue is resolved in a subsequent minor release of GHC 9.2, we can remove
+-- this workaround.
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Data.Dwarf.Types
   ( module Data.Dwarf.Types


### PR DESCRIPTION
Unfortunately, GHC 9.2 suffers from a bug in which `-Wmissing-signatures` will emit warnings about pattern synonyms even if `-Wmissing-pattern-synonym-signatures` is disabled. See https://gitlab.haskell.org/ghc/ghc/-/issues/14794#note_424553. Until that bug is fixed, we work around the issue by disabling `-Wmissing-signatures` in the affected modules.